### PR TITLE
Bug Fix: Reverse dtype for "bytez" variable

### DIFF
--- a/malware_rl/envs/utils/malconv.py
+++ b/malware_rl/envs/utils/malconv.py
@@ -41,7 +41,7 @@ class MalConv():
 
     def extract(self, bytez):
         b = np.ones((self.maxlen,), dtype=np.int16) * self.padding_char
-        bytez = np.frombuffer(bytez[:self.maxlen], dtype=np.int8)
+        bytez = np.frombuffer(bytez[:self.maxlen], dtype=np.uint8)
         b[:len(bytez)] = bytez
         return b
 


### PR DESCRIPTION
Bug associated with incorrect dtype meaning that the extract bytes array had negative numbers. This change does not affect Stable Baselines 3 compliance.