### PR TITLE
#21 fixes missing stable-baselines3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -67,6 +67,7 @@ rsa>=4.7
 scikit-learn==0.23.2
 scipy==1.4.1
 six==1.15.0
+stable-baselines3
 svn==1.0.1
 tensorboard==2.3.0
 tensorboard-plugin-wit==1.7.0


### PR DESCRIPTION
Addresses issue raised in https://github.com/bfilar/malware_rl/issues/21